### PR TITLE
Add rolling admissions UI enhancements to Overview tab

### DIFF
--- a/src/components/BulkActionsModal.jsx
+++ b/src/components/BulkActionsModal.jsx
@@ -19,6 +19,8 @@ const BulkActionsModal = ({ isOpen, selectedCount, onClose, onAction, isLoading 
         { value: 'reject_from_program', label: 'Reject from program' },
         { value: 'waitlist_applicant', label: 'Add to waitlist' },
         { value: 'defer_applicant', label: 'Defer application' },
+        { value: 'undefer_applicant', label: 'Remove deferral (return to active pool)' },
+        { value: 'allow_reapply', label: 'Allow reapply (for rejected applicants)' },
         { value: 'withdraw_applicant', label: 'Mark as withdrawn' },
         { value: 'send_custom_email', label: 'Send custom email' }
     ];
@@ -58,6 +60,10 @@ const BulkActionsModal = ({ isOpen, selectedCount, onClose, onAction, isLoading 
                 return 'Update admission status to "waitlisted" and send waitlist notification';
             case 'defer_applicant':
                 return 'Update admission status to "deferred" for future consideration';
+            case 'undefer_applicant':
+                return 'Remove deferral status and return applicant to active pool for current cohort';
+            case 'allow_reapply':
+                return 'Allow rejected applicant to reapply - they will be added to next cohort at info session stage';
             case 'withdraw_applicant':
                 return 'Update admission status to "withdrawn" - applicant has voluntarily withdrawn from consideration';
             case 'send_custom_email':

--- a/src/pages/AdmissionsDashboard/AdmissionsDashboard.jsx
+++ b/src/pages/AdmissionsDashboard/AdmissionsDashboard.jsx
@@ -283,11 +283,18 @@ const AdmissionsDashboard = () => {
     };
   }, [openFilterColumn]);
 
-  // Helper: robustly map overview quick view to a cohort_id or 'deferred'
+  // Helper: map overview quick view to a cohort_id or 'deferred'
   const getOverviewCohortParam = () => {
     if (!overviewQuickView || overviewQuickView === 'all_time') return '';
     if (overviewQuickView === 'deferred') return 'deferred';
+    
+    // If it's a UUID (cohort_id), return it directly
+    // UUIDs are 36 characters with hyphens
+    if (overviewQuickView.length === 36 && overviewQuickView.includes('-')) {
+      return overviewQuickView;
+    }
 
+    // Legacy support for hardcoded values (can be removed later)
     const norm = (s) => (s || '').toLowerCase();
     const candidates = cohorts || [];
 


### PR DESCRIPTION
## Summary
- Dynamic cohort dropdown populated from API (no longer hardcoded)
- Total Pool card shows Net New vs Rolled Over breakdown
- Info Session/Offers Extended show This Cohort vs Prior Cohorts breakdown
- Add "Opt Back In" button for deferred applicants

## Changes
- `OverviewTab.jsx`: Dynamic cohort selector, stat breakdowns, compare to last cycle for any cohort
- `ApplicantDashboard.jsx`: Opt-back-in button for deferred applicants to rejoin next cohort
- `AdmissionsDashboard.jsx`: Pass cohorts to OverviewTab
- `BulkActionsModal.jsx`: Minor deferral flow updates

## Test plan
- [x] Verify cohort dropdown shows all AI Native cohorts
- [x] Verify Net New / Rolled Over breakdown displays correctly
- [x] Verify This Cohort / Prior Cohorts breakdown for Info Sessions and Offers
- [x] Verify Compare to Last Cycle checkbox appears for specific cohorts
- [x] Test Opt Back In flow for deferred applicants

**Companion PR**: test-pilot-server#158 (backend query consistency)