### PR TITLE
Fix React Rules of Hooks violation in NavDropdown

### DIFF
--- a/src/components/Layout/NavDropdown.jsx
+++ b/src/components/Layout/NavDropdown.jsx
@@ -19,12 +19,6 @@ const NavDropdown = ({
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Don't render if condition is false
-  if (!condition) return null;
-
-  // Don't render on mobile if navbar is not open
-  if (isMobile && !isMobileNavbarOpen) return null;
-
   // Check if any of the dropdown items is currently active
   const isAnyItemActive = items.some(item => {
     if (item.to === location.pathname) return true;
@@ -33,11 +27,18 @@ const NavDropdown = ({
   });
 
   // Auto-expand when on an active route
+  // Must be called before any early returns to follow Rules of Hooks
   useEffect(() => {
-    if (isAnyItemActive && !isOpen) {
+    if (condition && isAnyItemActive && !isOpen) {
       onToggle(id);
     }
-  }, [location.pathname]); // Only run when pathname changes
+  }, [location.pathname, condition]); // Only run when pathname or condition changes
+
+  // Don't render if condition is false
+  if (!condition) return null;
+
+  // Don't render on mobile if navbar is not open
+  if (isMobile && !isMobileNavbarOpen) return null;
 
   const handleItemClick = (to) => {
     navigate(to);


### PR DESCRIPTION
## Summary
Fixes a React Rules of Hooks violation where `useEffect` was being called after early `return null` statements.

## Problem
React hooks must be called unconditionally at the top level of a component. The previous code had:
```jsx
if (!condition) return null;  // Early return
if (isMobile && !isMobileNavbarOpen) return null;  // Early return
// ... then useEffect was called
```

This violates React's rules and can cause warnings or inconsistent behavior.

## Solution
Move `useEffect` before the early returns and add `condition` to the dependency array:
```jsx
useEffect(() => {
  if (condition && isAnyItemActive && !isOpen) {
    onToggle(id);
  }
}, [location.pathname, condition]);

if (!condition) return null;  // Now after useEffect
```

## Test plan
- [x] Verify nav dropdown still works correctly
- [x] Verify no React hooks warnings in console