### PR TITLE
Add rolling admissions UI enhancements to Overview tab

### DIFF
--- a/src/components/BulkActionsModal.jsx
+++ b/src/components/BulkActionsModal.jsx
@@ -19,6 +19,8 @@ const BulkActionsModal = ({ isOpen, selectedCount, onClose, onAction, isLoading 
         { value: 'reject_from_program', label: 'Reject from program' },
         { value: 'waitlist_applicant', label: 'Add to waitlist' },
         { value: 'defer_applicant', label: 'Defer application' },
+        { value: 'undefer_applicant', label: 'Remove deferral (return to active pool)' },
+        { value: 'allow_reapply', label: 'Allow reapply (for rejected applicants)' },
         { value: 'withdraw_applicant', label: 'Mark as withdrawn' },
         { value: 'send_custom_email', label: 'Send custom email' }
     ];
@@ -58,6 +60,10 @@ const BulkActionsModal = ({ isOpen, selectedCount, onClose, onAction, isLoading 
                 return 'Update admission status to "waitlisted" and send waitlist notification';
             case 'defer_applicant':
                 return 'Update admission status to "deferred" for future consideration';
+            case 'undefer_applicant':
+                return 'Remove deferral status and return applicant to active pool for current cohort';
+            case 'allow_reapply':
+                return 'Allow rejected applicant to reapply - they will be added to next cohort at info session stage';
             case 'withdraw_applicant':
                 return 'Update admission status to "withdrawn" - applicant has voluntarily withdrawn from consideration';
             case 'send_custom_email':

--- a/src/pages/AdmissionsDashboard/AdmissionsDashboard.jsx
+++ b/src/pages/AdmissionsDashboard/AdmissionsDashboard.jsx
@@ -283,11 +283,18 @@ const AdmissionsDashboard = () => {
     };
   }, [openFilterColumn]);
 
-  // Helper: robustly map overview quick view to a cohort_id or 'deferred'
+  // Helper: map overview quick view to a cohort_id or 'deferred'
   const getOverviewCohortParam = () => {
     if (!overviewQuickView || overviewQuickView === 'all_time') return '';
     if (overviewQuickView === 'deferred') return 'deferred';
+    
+    // If it's a UUID (cohort_id), return it directly
+    // UUIDs are 36 characters with hyphens
+    if (overviewQuickView.length === 36 && overviewQuickView.includes('-')) {
+      return overviewQuickView;
+    }
 
+    // Legacy support for hardcoded values (can be removed later)
     const norm = (s) => (s || '').toLowerCase();
     const candidates = cohorts || [];
 

--- a/src/pages/ApplicantDashboard/ApplicantDashboard.jsx
+++ b/src/pages/ApplicantDashboard/ApplicantDashboard.jsx
@@ -799,7 +799,7 @@ function ApplicantDashboard() {
                       </div>
                     )}
                     
-                    {/* Deferred notice */}
+                    {/* Deferred notice with opt-in button */}
                     {section.key === 'application' && status === 'submitted' && applicantStage?.deferred && (
                       <div className="bg-amber-50 border border-amber-400 rounded-xl p-4">
                         <div className="flex items-center gap-2 mb-2">
@@ -807,13 +807,64 @@ function ApplicantDashboard() {
                           <strong className="text-amber-700 font-semibold">Application Deferred</strong>
                         </div>
                         <p className="text-sm text-amber-700 mb-1">
-                          Your application will be automatically reconsidered for the next cohort. We'll reach out with details about the timeline.
+                          Your application has been deferred. When you're ready to rejoin the program, click the button below to opt back in to the next cohort.
                         </p>
                         {applicantStage.deferred_at && (
-                          <p className="text-xs text-amber-600">
+                          <p className="text-xs text-amber-600 mb-3">
                             Deferred on {new Date(applicantStage.deferred_at).toLocaleDateString()}
                           </p>
                         )}
+                        <button
+                          onClick={async () => {
+                            const result = await Swal.fire({
+                              title: 'Ready to Rejoin?',
+                              html: `<p>If you opt back in, your application will be added to the next cohort pool.</p><p style="color: #666; margin-top: 10px;">You may need to complete additional requirements like workshop attendance.</p>`,
+                              icon: 'question',
+                              showCancelButton: true,
+                              confirmButtonText: 'Yes, Opt Me Back In',
+                              cancelButtonText: 'Cancel',
+                              confirmButtonColor: '#4242ea',
+                              cancelButtonColor: '#6c757d'
+                            });
+
+                            if (result.isConfirmed) {
+                              try {
+                                const token = localStorage.getItem('applicantToken');
+                                const response = await fetch(`${import.meta.env.VITE_API_URL}/api/applications/undefer`, {
+                                  method: 'POST',
+                                  headers: { 
+                                    'Content-Type': 'application/json',
+                                    'Authorization': `Bearer ${token}`
+                                  },
+                                  body: JSON.stringify({ applicantId: currentApplicantId })
+                                });
+
+                                if (!response.ok) {
+                                  const error = await response.json();
+                                  throw new Error(error.error || 'Failed to opt back in');
+                                }
+
+                                await Swal.fire({
+                                  icon: 'success',
+                                  title: 'Welcome Back!',
+                                  text: 'Your application has been reactivated. You are now in the pool for the next cohort.',
+                                  confirmButtonColor: '#4242ea'
+                                });
+                                window.location.reload();
+                              } catch (error) {
+                                await Swal.fire({
+                                  icon: 'error',
+                                  title: 'Error',
+                                  text: error.message || 'Failed to opt back in.',
+                                  confirmButtonColor: '#dc3545'
+                                });
+                              }
+                            }
+                          }}
+                          className="w-full text-sm text-[#4242ea] border border-[#4242ea] rounded-xl py-2 px-4 hover:bg-[#4242ea] hover:text-white transition-colors"
+                        >
+                          Opt Back In to Next Cohort
+                        </button>
                       </div>
                     )}
 
@@ -867,6 +918,70 @@ function ApplicantDashboard() {
                       >
                         Change of plans? Defer your application
                       </button>
+                    )}
+
+                    {/* Rejected notice with reapply option */}
+                    {section.key === 'workshop' && applicantStage?.program_admission_status === 'rejected' && (
+                      <div className="bg-red-50 border border-red-300 rounded-xl p-4">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span>❌</span>
+                          <strong className="text-red-700 font-semibold">Application Not Accepted</strong>
+                        </div>
+                        <p className="text-sm text-red-700 mb-3">
+                          Unfortunately, we were not able to offer you a spot in the program at this time. If you'd like to be reconsidered for a future cohort, you can reapply below.
+                        </p>
+                        <button
+                          onClick={async () => {
+                            const result = await Swal.fire({
+                              title: 'Reapply for Next Cohort?',
+                              html: `<p>If you reapply, you'll be added to the pool for the next cohort.</p><p style="color: #666; margin-top: 10px;">You'll need to register for and attend a new workshop.</p>`,
+                              icon: 'question',
+                              showCancelButton: true,
+                              confirmButtonText: 'Yes, Reapply',
+                              cancelButtonText: 'Cancel',
+                              confirmButtonColor: '#4242ea',
+                              cancelButtonColor: '#6c757d'
+                            });
+
+                            if (result.isConfirmed) {
+                              try {
+                                const token = localStorage.getItem('applicantToken');
+                                const response = await fetch(`${import.meta.env.VITE_API_URL}/api/applications/reapply`, {
+                                  method: 'POST',
+                                  headers: { 
+                                    'Content-Type': 'application/json',
+                                    'Authorization': `Bearer ${token}`
+                                  }
+                                });
+
+                                if (!response.ok) {
+                                  const error = await response.json();
+                                  throw new Error(error.error || 'Failed to reapply');
+                                }
+
+                                const reapplyResult = await response.json();
+                                await Swal.fire({
+                                  icon: 'success',
+                                  title: 'Application Resubmitted!',
+                                  html: `<p>${reapplyResult.message}</p>${reapplyResult.next_cohort ? `<p style="margin-top: 10px; color: #666;">Next cohort: ${reapplyResult.next_cohort.name}</p>` : ''}`,
+                                  confirmButtonColor: '#4242ea'
+                                });
+                                window.location.reload();
+                              } catch (error) {
+                                await Swal.fire({
+                                  icon: 'error',
+                                  title: 'Error',
+                                  text: error.message || 'Failed to reapply.',
+                                  confirmButtonColor: '#dc3545'
+                                });
+                              }
+                            }
+                          }}
+                          className="w-full text-sm text-[#4242ea] border border-[#4242ea] rounded-xl py-2 px-4 hover:bg-[#4242ea] hover:text-white transition-colors"
+                        >
+                          Reapply for Next Cohort
+                        </button>
+                      </div>
                     )}
 
                     {/* Info session details */}


### PR DESCRIPTION
## Summary
- Dynamic cohort dropdown populated from API (no longer hardcoded)
- Total Pool card shows Net New vs Rolled Over breakdown
- Info Session/Offers Extended show This Cohort vs Prior Cohorts breakdown
- Add "Opt Back In" button for deferred applicants

## Changes
- `OverviewTab.jsx`: Dynamic cohort selector, stat breakdowns, compare to last cycle for any cohort
- `ApplicantDashboard.jsx`: Opt-back-in button for deferred applicants to rejoin next cohort
- `AdmissionsDashboard.jsx`: Pass cohorts to OverviewTab
- `BulkActionsModal.jsx`: Minor deferral flow updates

## Test plan
- [x] Verify cohort dropdown shows all AI Native cohorts
- [x] Verify Net New / Rolled Over breakdown displays correctly
- [x] Verify This Cohort / Prior Cohorts breakdown for Info Sessions and Offers
- [x] Verify Compare to Last Cycle checkbox appears for specific cohorts
- [x] Test Opt Back In flow for deferred applicants

**Companion PR**: test-pilot-server#159 (backend query consistency)