### PR TITLE
fix: alias allAssessmentTypes to ALL_TYPES in GradeViewModal

### DIFF
--- a/src/pages/AssessmentGrades/GradeViewModal.jsx
+++ b/src/pages/AssessmentGrades/GradeViewModal.jsx
@@ -30,6 +30,7 @@ const assessmentTypeMapping = {
 };
 
 const ALL_TYPES = ['technical', 'business', 'professional', 'self'];
+const allAssessmentTypes = ALL_TYPES;
 
 // Smart website preview generator
 const createWebsitePreview = (files) => {


### PR DESCRIPTION
Merge renamed the constant but references still use the old name.