### PR TITLE
fix: correct JSX nesting at end of GradeViewModal — remove stray )} a…

### DIFF
--- a/src/pages/AssessmentGrades/GradeViewModal.jsx
+++ b/src/pages/AssessmentGrades/GradeViewModal.jsx
@@ -603,7 +603,6 @@ const GradeViewModal = ({
                 </>
               )}
             </div>
-          )}
           </Tabs>
         </div>
       </DialogContent>


### PR DESCRIPTION
…nd extra div