### PR TITLE
feat: add Export CSV button to Admissions LeadsTab

### DIFF
--- a/src/pages/AdmissionsDashboard/components/LeadsTab/LeadsTab.jsx
+++ b/src/pages/AdmissionsDashboard/components/LeadsTab/LeadsTab.jsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
 } from '../../../../components/ui/dropdown-menu';
-import { Upload, Settings, RefreshCw, ChevronDown, Users, FileInput } from 'lucide-react';
+import { Upload, Settings, RefreshCw, ChevronDown, Users, FileInput, Download } from 'lucide-react';
 import LeadImportModal from './LeadImportModal';
 import EmailListsManager from './EmailListsManager';
 import SourceConfigManager from './SourceConfigManager';
@@ -205,6 +205,9 @@ const LeadsTab = ({ token }) => {
   // Form import state
   const [formImporting, setFormImporting] = useState(false);
   const [formImportResult, setFormImportResult] = useState(null);
+
+  // Export state
+  const [exporting, setExporting] = useState(false);
 
   // Fetch leads
   const fetchLeads = useCallback(async () => {
@@ -481,6 +484,46 @@ const LeadsTab = ({ token }) => {
       setFormImportResult({ errors: [{ form: 'Unknown', error: error.message }] });
     } finally {
       setFormImporting(false);
+    }
+  };
+
+  // Export leads to CSV
+  const handleExportCSV = async () => {
+    try {
+      setExporting(true);
+      const params = new URLSearchParams();
+
+      if (selectedLeads.length > 0) {
+        params.append('lead_ids', selectedLeads.join(','));
+      } else {
+        if (filters.status.length > 0) params.append('status', filters.status.join(','));
+        if (filters.source_type) params.append('source_type', filters.source_type);
+        if (filters.list_id) params.append('list_id', filters.list_id);
+        if (filters.attended_event) params.append('attended_event', filters.attended_event);
+        if (filters.search) params.append('search', filters.search);
+      }
+
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/admissions/leads/export?${params}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+
+      if (!response.ok) throw new Error('Failed to export leads');
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = `admissions-leads-${new Date().toISOString().split('T')[0]}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Failed to export leads:', error);
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -972,6 +1015,20 @@ const LeadsTab = ({ token }) => {
           >
             <FileInput className="h-4 w-4" />
             {formImporting ? 'Importing…' : 'Import from Forms'}
+          </Button>
+
+          <Button
+            onClick={handleExportCSV}
+            disabled={exporting || (leads.length === 0 && selectedLeads.length === 0)}
+            variant="outline"
+            className="font-proxima gap-2"
+          >
+            <Download className="h-4 w-4" />
+            {exporting
+              ? 'Exporting...'
+              : selectedLeads.length > 0
+                ? `Export Selected (${selectedLeads.length})`
+                : 'Export CSV'}
           </Button>
 
           <Button

--- a/src/pages/AdmissionsDashboard/components/LeadsTab/LeadsTab.jsx
+++ b/src/pages/AdmissionsDashboard/components/LeadsTab/LeadsTab.jsx
@@ -24,6 +24,7 @@ import {
   DropdownMenuSubContent,
 } from '../../../../components/ui/dropdown-menu';
 import { Upload, Settings, RefreshCw, ChevronDown, Users, FileInput, Download } from 'lucide-react';
+import { toast } from 'sonner';
 import LeadImportModal from './LeadImportModal';
 import EmailListsManager from './EmailListsManager';
 import SourceConfigManager from './SourceConfigManager';
@@ -518,10 +519,11 @@ const LeadsTab = ({ token }) => {
       a.download = `admissions-leads-${new Date().toISOString().split('T')[0]}.csv`;
       document.body.appendChild(a);
       a.click();
-      window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
+      setTimeout(() => window.URL.revokeObjectURL(url), 100);
     } catch (error) {
       console.error('Failed to export leads:', error);
+      toast.error('Failed to export leads');
     } finally {
       setExporting(false);
     }

--- a/src/pages/PlatformIntake/PlatformIntake.jsx
+++ b/src/pages/PlatformIntake/PlatformIntake.jsx
@@ -198,9 +198,9 @@ export default function PlatformIntake() {
               <input
                 name="reporter"
                 value={form.reporter}
-                readOnly
+                onChange={handleChange}
                 required
-                className={`${inputClass} bg-gray-50 cursor-not-allowed`}
+                className={inputClass}
                 placeholder="Your full name"
               />
             </div>

--- a/src/pages/PlatformIntake/PlatformIntake.jsx
+++ b/src/pages/PlatformIntake/PlatformIntake.jsx
@@ -198,9 +198,9 @@ export default function PlatformIntake() {
               <input
                 name="reporter"
                 value={form.reporter}
-                onChange={handleChange}
+                readOnly
                 required
-                className={inputClass}
+                className={`${inputClass} bg-gray-50 cursor-not-allowed`}
                 placeholder="Your full name"
               />
             </div>

--- a/src/pages/TemplateManagement/TemplateManagement.jsx
+++ b/src/pages/TemplateManagement/TemplateManagement.jsx
@@ -1555,14 +1555,12 @@ function EmailTemplateFormWithPreview({ template, setTemplate, isEdit, token }) 
             />
           </div>
           <div>
-            <Label className="font-proxima">Slug (unique key) {isEdit ? '(read-only)' : '*'}</Label>
+            <Label className="font-proxima">Slug (unique key) *</Label>
             <Input
               value={template.slug || ''}
-              onChange={(e) => !isEdit && setTemplate({ ...template, slug: e.target.value })}
-              placeholder="e.g. week_2"
+              onChange={(e) => setTemplate({ ...template, slug: e.target.value })}
+              placeholder="e.g. l3_week_10"
               className="font-proxima font-mono"
-              readOnly={isEdit}
-              disabled={isEdit}
             />
           </div>
         </div>

--- a/src/pages/TemplateManagement/TemplateManagement.jsx
+++ b/src/pages/TemplateManagement/TemplateManagement.jsx
@@ -1301,6 +1301,8 @@ function AssessmentEmailTemplatesTab({ token }) {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState(null);
+  const [originalSlug, setOriginalSlug] = useState(null);
+  const [slugConfirmOpen, setSlugConfirmOpen] = useState(false);
 
   const fetchTemplates = async () => {
     try {
@@ -1334,23 +1336,36 @@ function AssessmentEmailTemplatesTab({ token }) {
 
   const handleEdit = (template) => {
     setEditingTemplate({ ...template });
+    setOriginalSlug(template.slug);
     setEditDialogOpen(true);
   };
 
-  const handleSaveEdit = async () => {
+  const doSaveEdit = async () => {
     try {
       const { template_id, created_at, updated_at, ...data } = editingTemplate;
-      await axios.put(
+      const res = await axios.put(
         `${API_URL}/api/admin/templates/assessment-emails/${template_id}`,
         data,
         { headers: { Authorization: `Bearer ${token}` } }
       );
+      if (res.data.success === false) {
+        toast.error(res.data.error || 'Failed to update email template');
+        return;
+      }
       toast.success('Email template updated');
       setEditDialogOpen(false);
       fetchTemplates();
     } catch (error) {
-      toast.error('Failed to update email template');
+      toast.error(error.response?.data?.error || 'Failed to update email template');
     }
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingTemplate.slug !== originalSlug) {
+      setSlugConfirmOpen(true);
+      return;
+    }
+    await doSaveEdit();
   };
 
   const handleCreate = async (form) => {
@@ -1431,6 +1446,30 @@ function AssessmentEmailTemplatesTab({ token }) {
         onOpenChange={setCreateDialogOpen}
         onCreate={handleCreate}
       />
+
+      {/* Slug Change Confirmation */}
+      <AlertDialog open={slugConfirmOpen} onOpenChange={setSlugConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="font-proxima">Change template slug?</AlertDialogTitle>
+            <AlertDialogDescription className="font-proxima">
+              Renaming the slug from <span className="font-mono font-semibold">{originalSlug}</span> to{' '}
+              <span className="font-mono font-semibold">{editingTemplate?.slug}</span> will break any
+              backend code, cron jobs, or API calls that reference the old slug. Make sure all
+              references are updated before proceeding.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="font-proxima">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-[#4242EA] hover:bg-[#3535cc] font-proxima"
+              onClick={() => { setSlugConfirmOpen(false); doSaveEdit(); }}
+            >
+              Change Slug & Save
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
Adds context-aware Export button that exports all filtered leads or only selected leads. Downloads CSV via blob from the new backend export endpoint.