### PR TITLE
fix: remove hardcoded jac@pursuit.org fallback causing phantom applic…

### DIFF
--- a/src/pages/ApplicationForm/ApplicationForm.jsx
+++ b/src/pages/ApplicationForm/ApplicationForm.jsx
@@ -47,19 +47,27 @@ const ApplicationForm = () => {
         setApplicationQuestions(questions);
         
         const savedUser = localStorage.getItem('user');
-        let email = 'jac@pursuit.org';
-        let firstName = 'John';
-        let lastName = 'Doe';
-        
-        if (savedUser) {
-          try {
-            const userData = JSON.parse(savedUser);
-            email = userData.email || email;
-            firstName = userData.firstName || userData.first_name || firstName;
-            lastName = userData.lastName || userData.last_name || lastName;
-          } catch (e) {
-            console.warn('Could not parse saved user data');
-          }
+        if (!savedUser) {
+          navigate('/login');
+          return;
+        }
+
+        let email, firstName, lastName;
+        try {
+          const userData = JSON.parse(savedUser);
+          email = userData.email;
+          firstName = userData.firstName || userData.first_name;
+          lastName = userData.lastName || userData.last_name;
+        } catch (e) {
+          console.warn('Could not parse saved user data');
+          navigate('/login');
+          return;
+        }
+
+        if (!email) {
+          console.warn('No email found in user data');
+          navigate('/login');
+          return;
         }
         
         const applicant = await databaseService.createOrGetApplicant(email, firstName, lastName);

--- a/src/pages/InfoSessions/InfoSessions.jsx
+++ b/src/pages/InfoSessions/InfoSessions.jsx
@@ -190,7 +190,7 @@ const InfoSessions = () => {
             const registrationData = {
                 applicantId: currentApplicantId,
                 name: user?.firstName || 'Applicant',
-                email: user?.email || 'jac@pursuit.org'
+                email: user?.email
             };
 
             const response = await fetch(`${import.meta.env.VITE_API_URL}/api/info-sessions/${eventId}/register`, {
@@ -225,7 +225,7 @@ const InfoSessions = () => {
                             registration_id: responseData.registration_id || `temp-${Date.now()}`,
                             applicant_id: currentApplicantId,
                             name: user?.firstName || 'Applicant',
-                            email: user?.email || 'jac@pursuit.org',
+                            email: user?.email,
                             status: 'registered',
                             registered_at: new Date().toISOString()
                         };

--- a/src/pages/Workshops/Workshops.jsx
+++ b/src/pages/Workshops/Workshops.jsx
@@ -165,7 +165,7 @@ const Workshops = () => {
             const registrationData = {
                 applicantId: currentApplicantId,
                 name: user?.firstName || 'Applicant',
-                email: user?.email || 'jac@pursuit.org',
+                email: user?.email,
                 needsLaptop: needsLaptop
             };
 
@@ -202,7 +202,7 @@ const Workshops = () => {
                             registration_id: responseData.registration_id || `temp-${Date.now()}`,
                             applicant_id: currentApplicantId,
                             name: user?.firstName || 'Applicant',
-                            email: user?.email || 'jac@pursuit.org',
+                            email: user?.email,
                             status: 'registered',
                             registered_at: new Date().toISOString(),
                             needs_laptop: needsLaptop
@@ -249,7 +249,7 @@ const Workshops = () => {
             const registrationData = {
                 applicantId: currentApplicantId,
                 name: user?.firstName || 'Applicant',
-                email: user?.email || 'jac@pursuit.org'
+                email: user?.email
             };
 
             const response = await fetch(`${import.meta.env.VITE_API_URL}/api/workshops/${eventId}/register`, {
@@ -284,7 +284,7 @@ const Workshops = () => {
                             registration_id: responseData.registration_id || `temp-${Date.now()}`,
                             applicant_id: currentApplicantId,
                             name: user?.firstName || 'Applicant',
-                            email: user?.email || 'jac@pursuit.org',
+                            email: user?.email,
                             status: 'registered',
                             registered_at: new Date().toISOString()
                         };


### PR DESCRIPTION
…ant records

Unauthenticated visitors to /apply would trigger createOrGetApplicant with the hardcoded fallback email, reinserting the record after every deletion. Now redirects to /login instead. Also cleaned up the same fallback in Workshops and InfoSessions registration data.