### PR TITLE
feat(pathfinder): admin dashboard enhancements + interview logging UI

### DIFF
--- a/src/pages/PathfinderAdmin/EmploymentRecords/EmploymentRecordsAdmin.jsx
+++ b/src/pages/PathfinderAdmin/EmploymentRecords/EmploymentRecordsAdmin.jsx
@@ -18,7 +18,7 @@ import EmploymentRecordForm from './EmploymentRecordForm';
 
 const API_URL = import.meta.env.VITE_API_URL;
 const ADMIN_ENDPOINT = `${API_URL}/api/pathfinder/admin/employment-records`;
-const BUILDERS_ENDPOINT = `${API_URL}/api/users/builders`;
+const BUILDERS_ENDPOINT = `${API_URL}/api/users/builders?limit=500&enrolled=true`;
 const LIMIT = 100;
 
 const DEFAULT_FILTERS = {
@@ -190,33 +190,46 @@ const EmploymentRecordsAdmin = () => {
   };
 
   const handleUpdate = async (formData) => {
-    const res = await fetch(`${ADMIN_ENDPOINT}/${editRecord.id}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(formData),
-    });
+    try {
+      const res = await fetch(`${ADMIN_ENDPOINT}/${editRecord.id}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
 
-    if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.error || 'Failed to update record');
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to update record');
+      }
+
+      Swal.fire({
+        toast: true,
+        icon: 'success',
+        title: 'Employment record updated',
+        position: 'top-end',
+        showConfirmButton: false,
+        timer: 3000,
+        timerProgressBar: true,
+      });
+
+      setFormOpen(false);
+      setEditRecord(null);
+      fetchRecords();
+    } catch (err) {
+      console.error('Error updating employment record:', err);
+      Swal.fire({
+        toast: true,
+        icon: 'error',
+        title: err.message || 'Could not update record',
+        position: 'top-end',
+        showConfirmButton: false,
+        timer: 4000,
+        timerProgressBar: true,
+      });
     }
-
-    Swal.fire({
-      toast: true,
-      icon: 'success',
-      title: 'Employment record updated',
-      position: 'top-end',
-      showConfirmButton: false,
-      timer: 3000,
-      timerProgressBar: true,
-    });
-
-    setFormOpen(false);
-    setEditRecord(null);
-    fetchRecords();
   };
 
   const handleDelete = async (record) => {

--- a/src/pages/PathfinderAdmin/PathfinderAdmin.jsx
+++ b/src/pages/PathfinderAdmin/PathfinderAdmin.jsx
@@ -378,7 +378,7 @@ function PathfinderAdmin() {
               await Promise.all([fetchProjects(), fetchProjectsOverview(), fetchPendingApprovals(), fetchApprovedPRDs()]);
               break;
             case 'job-applications':
-              await fetchJobApplications();
+              await Promise.all([fetchJobApplications(), fetchBuilders()]);
               break;
             case 'employment-records':
               fetchUnreviewedCount();
@@ -1443,7 +1443,9 @@ function PathfinderAdmin() {
                 setShowBuilderFilterModal={setShowBuilderFilterModal}
                 collapsedColumns={collapsedColumns}
                 toggleColumnCollapse={toggleColumnCollapse}
-                getUniqueBuilders={getUniqueBuilders}
+                builders={builders}
+                token={token}
+                onRefresh={fetchJobApplications}
               />
             </Suspense>
           </TabsContent>

--- a/src/pages/PathfinderAdmin/PathfinderAdmin.jsx
+++ b/src/pages/PathfinderAdmin/PathfinderAdmin.jsx
@@ -1320,6 +1320,13 @@ function PathfinderAdmin() {
                   setWeekOffset={setWeekOffset}
                   expandedHighlightGroups={expandedHighlightGroups}
                   toggleHighlightGroup={toggleHighlightGroup}
+                  token={token}
+                  cohortFilter={cohortFilter}
+                  onRefresh={() => {
+                    fetchOverview();
+                    fetchHighlights();
+                    fetchLeaderboard();
+                  }}
                 />
               )}
             </Suspense>

--- a/src/pages/PathfinderAdmin/components/JobApplicationsTab/JobApplicationsTab.jsx
+++ b/src/pages/PathfinderAdmin/components/JobApplicationsTab/JobApplicationsTab.jsx
@@ -1,9 +1,15 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../../components/ui/table';
 import { Card, CardContent } from '../../../../components/ui/card';
 import { Button } from '../../../../components/ui/button';
 import { Badge } from '../../../../components/ui/badge';
 import { Tabs, TabsList, TabsTrigger } from '../../../../components/ui/tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../../components/ui/dialog';
+import { Input } from '../../../../components/ui/input';
+import { Label } from '../../../../components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../../../components/ui/select';
+import { Textarea } from '../../../../components/ui/textarea';
+import Swal from 'sweetalert2';
 import KanbanBoard from '../shared/KanbanBoard';
 import JobApplicationDetailModal from '../shared/JobApplicationDetailModal';
 import BuilderFilterModal from '../shared/BuilderFilterModal';
@@ -25,8 +31,60 @@ const JobApplicationsTab = ({
   setShowBuilderFilterModal,
   collapsedColumns,
   toggleColumnCollapse,
-  getUniqueBuilders
+  builders,
+  token,
+  onRefresh
 }) => {
+  // Map builders to include full_name for BuilderFilterModal
+  const buildersWithFullName = (builders || []).map(b => ({
+    ...b,
+    full_name: `${b.first_name} ${b.last_name}`
+  }));
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [addForm, setAddForm] = useState({
+    builderId: '', companyName: '', roleTitle: '', stage: 'prospect',
+    dateApplied: new Date().toISOString().split('T')[0],
+    location: '', jobUrl: '', salaryRange: '', notes: '',
+    contactName: '', contactEmail: '', sourceType: ''
+  });
+  const [isAdding, setIsAdding] = useState(false);
+
+  const handleAddApplication = async () => {
+    if (!addForm.builderId || !addForm.companyName || !addForm.roleTitle) {
+      Swal.fire({ icon: 'warning', title: 'Required', text: 'Builder, company, and role are required.' });
+      return;
+    }
+    setIsAdding(true);
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/pathfinder/admin/job-applications`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify(addForm)
+        }
+      );
+      if (response.ok) {
+        Swal.fire({ icon: 'success', title: 'Added', text: 'Job application created.', timer: 1500, showConfirmButton: false });
+        setShowAddModal(false);
+        setAddForm({
+          builderId: '', companyName: '', roleTitle: '', stage: 'prospect',
+          dateApplied: new Date().toISOString().split('T')[0],
+          location: '', jobUrl: '', salaryRange: '', notes: '',
+          contactName: '', contactEmail: '', sourceType: ''
+        });
+        if (onRefresh) onRefresh();
+      } else {
+        const data = await response.json();
+        Swal.fire({ icon: 'error', title: 'Error', text: data.error || 'Failed to create application.' });
+      }
+    } catch (err) {
+      console.error('Add application error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to create application.' });
+    }
+    setIsAdding(false);
+  };
   const SortableHeader = ({ sortKey, children }) => (
     <TableHead 
       className="cursor-pointer select-none hover:bg-gray-50 transition-colors"
@@ -156,6 +214,14 @@ const JobApplicationsTab = ({
             <p className="text-sm text-gray-600">View all job applications submitted by builders</p>
           </div>
           
+          {/* Add Job Application Button */}
+          <Button
+            size="sm"
+            onClick={() => setShowAddModal(true)}
+          >
+            + Add Job
+          </Button>
+
           {/* Filter Button */}
           <Button
             variant="outline"
@@ -305,15 +371,110 @@ const JobApplicationsTab = ({
         application={selectedJobApplication}
         open={!!selectedJobApplication}
         onOpenChange={(open) => !open && setSelectedJobApplication(null)}
+        token={token}
+        onRefresh={onRefresh}
       />
-      
+
       <BuilderFilterModal
         open={showBuilderFilterModal}
         onOpenChange={setShowBuilderFilterModal}
-        builders={getUniqueBuilders()}
+        builders={buildersWithFullName}
         selectedBuilder={selectedBuilderFilter}
         onSelectBuilder={setSelectedBuilderFilter}
       />
+
+      {/* Add Job Application Modal */}
+      <Dialog open={showAddModal} onOpenChange={setShowAddModal}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Add Job Application</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label className="text-xs text-gray-600">Builder *</Label>
+              <Select value={addForm.builderId ? String(addForm.builderId) : ''} onValueChange={v => setAddForm({ ...addForm, builderId: parseInt(v) })}>
+                <SelectTrigger><SelectValue placeholder="Select Builder" /></SelectTrigger>
+                <SelectContent>
+                  {buildersWithFullName.map(b => (
+                    <SelectItem key={b.builder_id} value={String(b.builder_id)}>{b.full_name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label className="text-xs text-gray-600">Company *</Label>
+                <Input value={addForm.companyName} onChange={e => setAddForm({ ...addForm, companyName: e.target.value })} />
+              </div>
+              <div>
+                <Label className="text-xs text-gray-600">Role *</Label>
+                <Input value={addForm.roleTitle} onChange={e => setAddForm({ ...addForm, roleTitle: e.target.value })} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label className="text-xs text-gray-600">Stage</Label>
+                <Select value={addForm.stage} onValueChange={v => setAddForm({ ...addForm, stage: v })}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="prospect">Prospect</SelectItem>
+                    <SelectItem value="applied">Applied</SelectItem>
+                    <SelectItem value="screen">Phone Screen</SelectItem>
+                    <SelectItem value="oa">Online Assessment</SelectItem>
+                    <SelectItem value="interview">Interview</SelectItem>
+                    <SelectItem value="offer">Offer</SelectItem>
+                    <SelectItem value="accepted">Accepted</SelectItem>
+                    <SelectItem value="rejected">Rejected</SelectItem>
+                    <SelectItem value="withdrawn">Withdrawn</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label className="text-xs text-gray-600">Date Applied</Label>
+                <Input type="date" value={addForm.dateApplied} onChange={e => setAddForm({ ...addForm, dateApplied: e.target.value })} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label className="text-xs text-gray-600">Location</Label>
+                <Input value={addForm.location} onChange={e => setAddForm({ ...addForm, location: e.target.value })} />
+              </div>
+              <div>
+                <Label className="text-xs text-gray-600">Salary Range</Label>
+                <Input value={addForm.salaryRange} onChange={e => setAddForm({ ...addForm, salaryRange: e.target.value })} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label className="text-xs text-gray-600">Contact Name</Label>
+                <Input value={addForm.contactName} onChange={e => setAddForm({ ...addForm, contactName: e.target.value })} />
+              </div>
+              <div>
+                <Label className="text-xs text-gray-600">Contact Email</Label>
+                <Input value={addForm.contactEmail} onChange={e => setAddForm({ ...addForm, contactEmail: e.target.value })} />
+              </div>
+            </div>
+            <div>
+              <Label className="text-xs text-gray-600">Job URL</Label>
+              <Input value={addForm.jobUrl} onChange={e => setAddForm({ ...addForm, jobUrl: e.target.value })} />
+            </div>
+            <div>
+              <Label className="text-xs text-gray-600">Source</Label>
+              <Input value={addForm.sourceType} onChange={e => setAddForm({ ...addForm, sourceType: e.target.value })} placeholder="e.g. LinkedIn, Referral, Job Board" />
+            </div>
+            <div>
+              <Label className="text-xs text-gray-600">Notes</Label>
+              <Textarea value={addForm.notes} onChange={e => setAddForm({ ...addForm, notes: e.target.value })} rows={3} />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setShowAddModal(false)}>Cancel</Button>
+              <Button onClick={handleAddApplication} disabled={isAdding}>
+                {isAdding ? 'Adding...' : 'Add Application'}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/pages/PathfinderAdmin/components/OverviewTab/OverviewTab.jsx
+++ b/src/pages/PathfinderAdmin/components/OverviewTab/OverviewTab.jsx
@@ -1,7 +1,10 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../../../../components/ui/card';
 import { Button } from '../../../../components/ui/button';
+import { Input } from '../../../../components/ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../../components/ui/dialog';
 import { getWeekDateRange, getMilestoneInfo } from '../shared/utils';
+import JobApplicationDetailModal from '../shared/JobApplicationDetailModal';
 
 const OverviewTab = ({
   overview,
@@ -10,9 +13,81 @@ const OverviewTab = ({
   weekOffset,
   setWeekOffset,
   expandedHighlightGroups,
-  toggleHighlightGroup
+  toggleHighlightGroup,
+  token,
+  cohortFilter,
+  onRefresh
 }) => {
   if (!overview) return null;
+
+  // Interview picker state
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerStep, setPickerStep] = useState('builder');
+  const [builders, setBuilders] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedBuilder, setSelectedBuilder] = useState(null);
+  const [applications, setApplications] = useState([]);
+  const [selectedApplication, setSelectedApplication] = useState(null);
+  const [pickerLoading, setPickerLoading] = useState(false);
+
+  const openPicker = async () => {
+    setShowPicker(true);
+    setPickerStep('builder');
+    setSearchQuery('');
+    setSelectedBuilder(null);
+    setApplications([]);
+    setPickerLoading(true);
+    try {
+      let url = `${import.meta.env.VITE_API_URL}/api/pathfinder/admin/builders`;
+      if (cohortFilter && cohortFilter !== 'all') {
+        url += `?cohort=${encodeURIComponent(cohortFilter)}`;
+      }
+      const res = await fetch(url, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      setBuilders(data);
+    } catch (err) {
+      console.error('Error fetching builders:', err);
+    } finally {
+      setPickerLoading(false);
+    }
+  };
+
+  const selectBuilder = async (builder) => {
+    setSelectedBuilder(builder);
+    setPickerStep('application');
+    setPickerLoading(true);
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/pathfinder/admin/builders/${builder.builder_id}`,
+        { headers: { 'Authorization': `Bearer ${token}` } }
+      );
+      const data = await res.json();
+      setApplications(data.applications?.data || []);
+    } catch (err) {
+      console.error('Error fetching builder applications:', err);
+    } finally {
+      setPickerLoading(false);
+    }
+  };
+
+  const selectApplication = (app) => {
+    setSelectedApplication(app);
+    setShowPicker(false);
+  };
+
+  const closePicker = () => {
+    setShowPicker(false);
+    setPickerStep('builder');
+    setSearchQuery('');
+    setSelectedBuilder(null);
+    setApplications([]);
+  };
+
+  const filteredBuilders = builders.filter(b =>
+    `${b.first_name} ${b.last_name}`.toLowerCase().includes(searchQuery.toLowerCase())
+  );
 
   const renderLeaderboard = (types, isWeekly = true) => {
     if (leaderboard.length === 0) {
@@ -336,6 +411,13 @@ const OverviewTab = ({
           </h2>
           <div className="flex gap-2">
             <Button
+              size="sm"
+              onClick={openPicker}
+              className="bg-[#4242ea] text-white hover:bg-[#3333d1]"
+            >
+              Log Interview
+            </Button>
+            <Button
               variant="outline"
               size="sm"
               onClick={() => setWeekOffset(weekOffset - 1)}
@@ -459,6 +541,83 @@ const OverviewTab = ({
         {/* All Time Stats Grid */}
         {renderStats(false)}
       </div>
+
+      {/* Builder/Application Picker Dialog */}
+      <Dialog open={showPicker} onOpenChange={(open) => { if (!open) closePicker(); }}>
+        <DialogContent className="max-w-md max-h-[80vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>
+              {pickerStep === 'builder' ? 'Select a Builder' : `${selectedBuilder?.first_name} ${selectedBuilder?.last_name} - Select Application`}
+            </DialogTitle>
+          </DialogHeader>
+
+          {pickerStep === 'builder' && (
+            <div className="flex flex-col gap-3 overflow-hidden">
+              <Input
+                placeholder="Search Builders..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+              <div className="overflow-y-auto max-h-[50vh] space-y-1">
+                {pickerLoading ? (
+                  <p className="text-sm text-gray-500 p-4 text-center">Loading...</p>
+                ) : filteredBuilders.length === 0 ? (
+                  <p className="text-sm text-gray-500 p-4 text-center">No Builders found</p>
+                ) : (
+                  filteredBuilders.map(b => (
+                    <button
+                      key={b.builder_id}
+                      onClick={() => selectBuilder(b)}
+                      className="w-full text-left px-3 py-2 rounded hover:bg-[#f0f0f0] transition-colors text-sm"
+                    >
+                      <span className="font-medium">{b.first_name} {b.last_name}</span>
+                      <span className="text-gray-500 ml-2">({b.application_count || 0} applications)</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+
+          {pickerStep === 'application' && (
+            <div className="flex flex-col gap-3 overflow-hidden">
+              <Button variant="ghost" size="sm" onClick={() => { setPickerStep('builder'); setSearchQuery(''); }} className="self-start">
+                Back to Builders
+              </Button>
+              <div className="overflow-y-auto max-h-[50vh] space-y-1">
+                {pickerLoading ? (
+                  <p className="text-sm text-gray-500 p-4 text-center">Loading...</p>
+                ) : applications.length === 0 ? (
+                  <p className="text-sm text-gray-500 p-4 text-center">No applications found for this Builder</p>
+                ) : (
+                  applications.map(app => (
+                    <button
+                      key={app.job_application_id}
+                      onClick={() => selectApplication(app)}
+                      className="w-full text-left px-3 py-2 rounded hover:bg-[#f0f0f0] transition-colors text-sm border border-[#e0e0e0] mb-1"
+                    >
+                      <div className="font-medium">{app.company_name}</div>
+                      <div className="text-gray-500">{app.role_title || 'No role specified'} - {app.stage}</div>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Job Application Detail Modal (for logging interview) */}
+      <JobApplicationDetailModal
+        application={selectedApplication}
+        open={!!selectedApplication}
+        onOpenChange={(open) => { if (!open) setSelectedApplication(null); }}
+        token={token}
+        onRefresh={() => {
+          setSelectedApplication(null);
+          if (onRefresh) onRefresh();
+        }}
+      />
     </div>
   );
 };

--- a/src/pages/PathfinderAdmin/components/shared/JobApplicationDetailModal.jsx
+++ b/src/pages/PathfinderAdmin/components/shared/JobApplicationDetailModal.jsx
@@ -1,23 +1,133 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../../../components/ui/dialog';
 import { Badge } from '../../../../components/ui/badge';
-import { formatSalary } from '../../../../utils/salaryFormatter';
+import { Button } from '../../../../components/ui/button';
+import { Input } from '../../../../components/ui/input';
+import { Label } from '../../../../components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../../../components/ui/select';
+import { Textarea } from '../../../../components/ui/textarea';
+import Swal from 'sweetalert2';
 import { getStageLabel } from './utils';
 
-const JobApplicationDetailModal = ({ application, open, onOpenChange }) => {
+const STAGES = [
+  { value: 'prospect', label: 'Prospect' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'screen', label: 'Phone Screen' },
+  { value: 'oa', label: 'Online Assessment' },
+  { value: 'interview', label: 'Interview' },
+  { value: 'offer', label: 'Offer' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'withdrawn', label: 'Withdrawn' }
+];
+
+const INTERVIEW_TYPES = [
+  'Phone Screen', 'Technical', 'Behavioral', 'Final Round', 'Panel', 'Take Home', 'Culture Fit'
+];
+
+const JobApplicationDetailModal = ({ application, open, onOpenChange, token, onRefresh }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [showInterviewForm, setShowInterviewForm] = useState(false);
+  const [form, setForm] = useState({});
+  const [interviewForm, setInterviewForm] = useState({
+    date: '', type: '', title: '', interviewerName: '', interviewerEmail: '', contentType: '', feedback: ''
+  });
+
+  useEffect(() => {
+    if (application) {
+      setForm({
+        companyName: application.company_name || '',
+        roleTitle: application.role_title || '',
+        stage: application.stage || 'prospect',
+        location: application.location || '',
+        jobUrl: application.job_url || '',
+        salaryRange: application.salary_range || '',
+        salary: application.salary || '',
+        finalSalary: application.final_salary || '',
+        startDate: application.start_date ? application.start_date.split('T')[0] : '',
+        jobType: application.job_type || '',
+        dateApplied: application.date_applied ? application.date_applied.split('T')[0] : '',
+        sourceType: application.source_type || '',
+        internalReferral: application.internal_referral || false,
+        contactName: application.contact_name || '',
+        contactTitle: application.contact_title || '',
+        contactEmail: application.contact_email || '',
+        contactPhone: application.contact_phone || '',
+        notes: application.notes || '',
+        acceptanceNotes: application.acceptance_notes || '',
+        withdrawalReason: application.withdrawal_reason || ''
+      });
+      setIsEditing(false);
+      setShowInterviewForm(false);
+    }
+  }, [application]);
+
   if (!application) return null;
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/pathfinder/admin/job-applications/${application.job_application_id}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify(form)
+        }
+      );
+
+      if (response.ok) {
+        Swal.fire({ icon: 'success', title: 'Saved', text: 'Application updated.', timer: 1500, showConfirmButton: false });
+        setIsEditing(false);
+        if (onRefresh) onRefresh();
+      } else {
+        const data = await response.json();
+        Swal.fire({ icon: 'error', title: 'Error', text: data.error || 'Failed to save.' });
+      }
+    } catch (err) {
+      console.error('Save error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to save.' });
+    }
+    setIsSaving(false);
+  };
+
+  const handleAddInterview = async () => {
+    if (!interviewForm.date || !interviewForm.type) {
+      Swal.fire({ icon: 'warning', title: 'Required', text: 'Date and type are required.' });
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_API_URL}/api/pathfinder/admin/interviews/${application.job_application_id}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify(interviewForm)
+        }
+      );
+
+      if (response.ok) {
+        Swal.fire({ icon: 'success', title: 'Interview Added', timer: 1500, showConfirmButton: false });
+        setShowInterviewForm(false);
+        setInterviewForm({ date: '', type: '', title: '', interviewerName: '', interviewerEmail: '', contentType: '', feedback: '' });
+        if (onRefresh) onRefresh();
+      } else {
+        const data = await response.json();
+        Swal.fire({ icon: 'error', title: 'Error', text: data.error || 'Failed to add interview.' });
+      }
+    } catch (err) {
+      console.error('Interview error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to add interview.' });
+    }
+  };
 
   const getStageBadgeVariant = (stage) => {
     const variants = {
-      prospect: 'secondary',
-      applied: 'default',
-      screen: 'default',
-      oa: 'default',
-      interview: 'default',
-      offer: 'default',
-      accepted: 'default',
-      rejected: 'destructive',
-      withdrawn: 'outline'
+      prospect: 'secondary', applied: 'default', screen: 'default', oa: 'default',
+      interview: 'default', offer: 'default', accepted: 'default',
+      rejected: 'destructive', withdrawn: 'outline'
     };
     return variants[stage] || 'secondary';
   };
@@ -26,9 +136,23 @@ const JobApplicationDetailModal = ({ application, open, onOpenChange }) => {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-xl font-semibold">
-            {application.company_name} - {application.role_title}
-          </DialogTitle>
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl font-semibold">
+              {application.company_name} - {application.role_title}
+            </DialogTitle>
+            <div className="flex gap-2">
+              {!isEditing ? (
+                <Button size="sm" onClick={() => setIsEditing(true)}>Edit</Button>
+              ) : (
+                <>
+                  <Button size="sm" variant="outline" onClick={() => setIsEditing(false)}>Cancel</Button>
+                  <Button size="sm" onClick={handleSave} disabled={isSaving}>
+                    {isSaving ? 'Saving...' : 'Save'}
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
         </DialogHeader>
 
         <div className="space-y-6">
@@ -48,204 +172,277 @@ const JobApplicationDetailModal = ({ application, open, onOpenChange }) => {
               <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-[#4242ea]">
                 Job Information
               </h3>
-              
+
               <div className="space-y-4">
-                <div>
-                  <div className="text-xs text-gray-600 mb-1">Company</div>
-                  <div className="font-semibold">{application.company_name}</div>
-                </div>
-
-                <div>
-                  <div className="text-xs text-gray-600 mb-1">Role</div>
-                  <div className="font-semibold">{application.role_title}</div>
-                </div>
-
-                {application.location && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Location</div>
-                    <div>{application.location}</div>
-                  </div>
-                )}
-
-                {application.job_url && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Job URL</div>
-                    <a 
-                      href={application.job_url} 
-                      target="_blank" 
-                      rel="noopener noreferrer" 
-                      className="text-[#4242ea] underline hover:text-[#3333d1]"
-                    >
-                      View Job Posting
-                    </a>
-                  </div>
-                )}
-
-                {formatSalary(application) && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Salary Range</div>
-                    <div>{formatSalary(application)}</div>
-                  </div>
-                )}
-
-                {application.job_type && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Job Type</div>
-                    <div className="capitalize">{application.job_type.replace(/-/g, ' ')}</div>
-                  </div>
-                )}
-
-                <div>
-                  <div className="text-xs text-gray-600 mb-1">Stage</div>
-                  <Badge variant={getStageBadgeVariant(application.stage)}>
-                    {getStageLabel(application.stage)}
-                  </Badge>
-                </div>
-
-                <div>
-                  <div className="text-xs text-gray-600 mb-1">Date Applied</div>
-                  <div>{new Date(application.date_applied).toLocaleDateString()}</div>
-                </div>
-
-                {application.source_type && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Source</div>
-                    <div>{application.source_type}</div>
-                  </div>
-                )}
-
-                {application.internal_referral && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Referral</div>
-                    <Badge variant="secondary" className="bg-green-100 text-green-700">
-                      ✓ Internal Referral
-                    </Badge>
-                  </div>
+                {isEditing ? (
+                  <>
+                    <div>
+                      <Label className="text-xs text-gray-600">Company</Label>
+                      <Input value={form.companyName} onChange={e => setForm({ ...form, companyName: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Role</Label>
+                      <Input value={form.roleTitle} onChange={e => setForm({ ...form, roleTitle: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Stage</Label>
+                      <Select value={form.stage} onValueChange={v => setForm({ ...form, stage: v })}>
+                        <SelectTrigger><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          {STAGES.map(s => <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>)}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Location</Label>
+                      <Input value={form.location} onChange={e => setForm({ ...form, location: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Job URL</Label>
+                      <Input value={form.jobUrl} onChange={e => setForm({ ...form, jobUrl: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Salary Range</Label>
+                      <Input value={form.salaryRange} onChange={e => setForm({ ...form, salaryRange: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Date Applied</Label>
+                      <Input type="date" value={form.dateApplied} onChange={e => setForm({ ...form, dateApplied: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Source</Label>
+                      <Input value={form.sourceType} onChange={e => setForm({ ...form, sourceType: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Final Salary</Label>
+                      <Input value={form.finalSalary} onChange={e => setForm({ ...form, finalSalary: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Start Date</Label>
+                      <Input type="date" value={form.startDate} onChange={e => setForm({ ...form, startDate: e.target.value })} />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div>
+                      <div className="text-xs text-gray-600 mb-1">Company</div>
+                      <div className="font-semibold">{application.company_name}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-gray-600 mb-1">Role</div>
+                      <div className="font-semibold">{application.role_title}</div>
+                    </div>
+                    {application.location && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Location</div>
+                        <div>{application.location}</div>
+                      </div>
+                    )}
+                    {application.job_url && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Job URL</div>
+                        <a href={application.job_url} target="_blank" rel="noopener noreferrer" className="text-[#4242ea] underline hover:text-[#3333d1]">View Job Posting</a>
+                      </div>
+                    )}
+                    {(application.salary_range || application.salary) && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Salary</div>
+                        <div>{application.salary_range || application.salary}</div>
+                      </div>
+                    )}
+                    <div>
+                      <div className="text-xs text-gray-600 mb-1">Stage</div>
+                      <Badge variant={getStageBadgeVariant(application.stage)}>{getStageLabel(application.stage)}</Badge>
+                    </div>
+                    <div>
+                      <div className="text-xs text-gray-600 mb-1">Date Applied</div>
+                      <div>{new Date(application.date_applied).toLocaleDateString()}</div>
+                    </div>
+                    {application.source_type && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Source</div>
+                        <div>{application.source_type}</div>
+                      </div>
+                    )}
+                    {application.internal_referral && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Referral</div>
+                        <Badge variant="secondary" className="bg-green-100 text-green-700">Internal Referral</Badge>
+                      </div>
+                    )}
+                    {application.final_salary && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Final Salary</div>
+                        <div className="font-semibold text-green-600">{application.final_salary}</div>
+                      </div>
+                    )}
+                    {application.start_date && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Start Date</div>
+                        <div>{new Date(application.start_date).toLocaleDateString()}</div>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
             </div>
 
-            {/* Right Column - Contact & Additional Info */}
+            {/* Right Column - Contact & Details */}
             <div>
               <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-green-500">
                 Contact & Details
               </h3>
-              
+
               <div className="space-y-4">
-                {application.contact_name && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Contact Name</div>
-                    <div>{application.contact_name}</div>
-                  </div>
-                )}
-
-                {application.contact_title && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Contact Title</div>
-                    <div>{application.contact_title}</div>
-                  </div>
-                )}
-
-                {application.contact_email && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Contact Email</div>
-                    <a 
-                      href={`mailto:${application.contact_email}`} 
-                      className="text-[#4242ea] hover:underline"
-                    >
-                      {application.contact_email}
-                    </a>
-                  </div>
-                )}
-
-                {application.contact_phone && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Contact Phone</div>
-                    <div>{application.contact_phone}</div>
-                  </div>
-                )}
-
-                {application.response_received && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Response Received</div>
-                    <div className="text-green-600 font-semibold">✓ Yes</div>
-                    {application.response_date && (
-                      <div className="text-xs text-gray-600 mt-1">
-                        on {new Date(application.response_date).toLocaleDateString()}
+                {isEditing ? (
+                  <>
+                    <div>
+                      <Label className="text-xs text-gray-600">Contact Name</Label>
+                      <Input value={form.contactName} onChange={e => setForm({ ...form, contactName: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Contact Title</Label>
+                      <Input value={form.contactTitle} onChange={e => setForm({ ...form, contactTitle: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Contact Email</Label>
+                      <Input value={form.contactEmail} onChange={e => setForm({ ...form, contactEmail: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Contact Phone</Label>
+                      <Input value={form.contactPhone} onChange={e => setForm({ ...form, contactPhone: e.target.value })} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Notes</Label>
+                      <Textarea value={form.notes} onChange={e => setForm({ ...form, notes: e.target.value })} rows={3} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Acceptance Notes</Label>
+                      <Textarea value={form.acceptanceNotes} onChange={e => setForm({ ...form, acceptanceNotes: e.target.value })} rows={3} />
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-600">Withdrawal Reason</Label>
+                      <Textarea value={form.withdrawalReason} onChange={e => setForm({ ...form, withdrawalReason: e.target.value })} rows={2} />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    {application.contact_name && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Contact Name</div>
+                        <div>{application.contact_name}</div>
                       </div>
                     )}
-                  </div>
-                )}
-
-                {application.interview_count > 0 && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Interviews</div>
-                    <Badge variant="secondary" className="bg-orange-100 text-orange-700">
-                      {application.interview_count}
-                    </Badge>
-                  </div>
-                )}
-
-                {(application.stage === 'accepted' || application.stage === 'offer') && application.final_salary && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Final Salary</div>
-                    <div className="font-semibold text-green-600">{application.final_salary}</div>
-                  </div>
-                )}
-
-                {application.start_date && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Start Date</div>
-                    <div>{new Date(application.start_date).toLocaleDateString()}</div>
-                  </div>
-                )}
-
-                {application.stage === 'withdrawn' && application.withdrawal_reason && (
-                  <div>
-                    <div className="text-xs text-gray-600 mb-1">Withdrawal Reason</div>
-                    <div className="text-red-600">{application.withdrawal_reason}</div>
-                  </div>
+                    {application.contact_title && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Contact Title</div>
+                        <div>{application.contact_title}</div>
+                      </div>
+                    )}
+                    {application.contact_email && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Contact Email</div>
+                        <a href={`mailto:${application.contact_email}`} className="text-[#4242ea] hover:underline">{application.contact_email}</a>
+                      </div>
+                    )}
+                    {application.contact_phone && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Contact Phone</div>
+                        <div>{application.contact_phone}</div>
+                      </div>
+                    )}
+                    {application.interview_count > 0 && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Interviews</div>
+                        <Badge variant="secondary" className="bg-orange-100 text-orange-700">{application.interview_count}</Badge>
+                      </div>
+                    )}
+                    {application.stage === 'withdrawn' && application.withdrawal_reason && (
+                      <div>
+                        <div className="text-xs text-gray-600 mb-1">Withdrawal Reason</div>
+                        <div className="text-red-600">{application.withdrawal_reason}</div>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
             </div>
           </div>
 
-          {/* Job Description */}
-          {application.job_description && (
+          {/* Notes (read-only view) */}
+          {!isEditing && application.notes && (
             <div className="mt-8">
-              <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-amber-500">
-                Job Description
-              </h3>
-              <div 
-                className="p-4 bg-gray-50 rounded-lg max-h-[300px] overflow-y-auto text-sm leading-relaxed"
-                dangerouslySetInnerHTML={{ __html: application.job_description }}
-              />
+              <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-purple-500">Notes</h3>
+              <div className="p-4 bg-purple-50 rounded-lg text-sm leading-relaxed italic">{application.notes}</div>
             </div>
           )}
 
-          {/* Notes */}
-          {application.notes && (
+          {/* Acceptance Notes (read-only view) */}
+          {!isEditing && application.acceptance_notes && (
             <div className="mt-8">
-              <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-purple-500">
-                Notes
-              </h3>
-              <div className="p-4 bg-purple-50 rounded-lg text-sm leading-relaxed italic">
-                {application.notes}
-              </div>
+              <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-green-500">Acceptance Notes</h3>
+              <div className="p-4 bg-green-50 rounded-lg text-sm leading-relaxed">{application.acceptance_notes}</div>
             </div>
           )}
 
-          {/* Acceptance Notes */}
-          {application.acceptance_notes && (
-            <div className="mt-8">
-              <h3 className="text-lg font-semibold mb-4 pb-2 border-b-2 border-green-500">
-                Acceptance Notes
-              </h3>
-              <div className="p-4 bg-green-50 rounded-lg text-sm leading-relaxed">
-                {application.acceptance_notes}
-              </div>
+          {/* Add Interview Section */}
+          <div className="mt-8 border-t pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">Interviews</h3>
+              <Button size="sm" variant="outline" onClick={() => setShowInterviewForm(!showInterviewForm)}>
+                {showInterviewForm ? 'Cancel' : 'Add Interview'}
+              </Button>
             </div>
-          )}
+
+            {showInterviewForm && (
+              <div className="p-4 bg-gray-50 rounded-lg space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-xs text-gray-600">Date *</Label>
+                    <Input type="date" value={interviewForm.date} onChange={e => setInterviewForm({ ...interviewForm, date: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-gray-600">Type *</Label>
+                    <Select value={interviewForm.type} onValueChange={v => setInterviewForm({ ...interviewForm, type: v })}>
+                      <SelectTrigger><SelectValue placeholder="Select type" /></SelectTrigger>
+                      <SelectContent>
+                        {INTERVIEW_TYPES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label className="text-xs text-gray-600">Title</Label>
+                    <Input value={interviewForm.title} onChange={e => setInterviewForm({ ...interviewForm, title: e.target.value })} placeholder="e.g. Round 2 with Engineering" />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-gray-600">Interviewer Name</Label>
+                    <Input value={interviewForm.interviewerName} onChange={e => setInterviewForm({ ...interviewForm, interviewerName: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-gray-600">Interviewer Email</Label>
+                    <Input value={interviewForm.interviewerEmail} onChange={e => setInterviewForm({ ...interviewForm, interviewerEmail: e.target.value })} />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-gray-600">Content Type</Label>
+                    <Select value={interviewForm.contentType} onValueChange={v => setInterviewForm({ ...interviewForm, contentType: v })}>
+                      <SelectTrigger><SelectValue placeholder="Select" /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="technical">Technical</SelectItem>
+                        <SelectItem value="behavioral">Behavioral</SelectItem>
+                        <SelectItem value="hr">HR</SelectItem>
+                        <SelectItem value="case_study">Case Study</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs text-gray-600">Feedback</Label>
+                  <Textarea value={interviewForm.feedback} onChange={e => setInterviewForm({ ...interviewForm, feedback: e.target.value })} rows={2} />
+                </div>
+                <Button size="sm" onClick={handleAddInterview}>Save Interview</Button>
+              </div>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>
@@ -253,4 +450,3 @@ const JobApplicationDetailModal = ({ application, open, onOpenChange }) => {
 };
 
 export default JobApplicationDetailModal;
-


### PR DESCRIPTION
## Summary

- Add "Log Interview" button to admin Overview tab with builder/application picker dialog
- Admin job management UI and builder dropdown fixes
- Rename "Add Job" to "Track Application" and "Log a Job" to "Log Work" across Builder dashboard
- Add unreviewed badge and acknowledge flow to Builder Jobs Dashboard tab
- Restructure admin tabs from 10 down to 7 (combine Projects+PRDs, remove Weekly Goals and Ceremonies)
- Add Employment Records admin tab with cards, stats, filters, CRUD form
- Dashboard redesign with goal statement, progress bar, and weekly goals
- Portfolio field and industry alignment with Sputnik

## Migration Required

**The companion server PR must be merged first**, and `db/migrations/041_pathfinder_phase1.sql` must be run against the production database. Without it, My Strategy and resume upload features will fail with "Failed to save" errors.

## Test plan

- [ ] Verify admin Overview tab "Log Interview" button opens builder picker, then application picker, then interview form
- [ ] Verify admin Builders tab shows correct interview counts
- [ ] Verify Builder dashboard shows "Track Application" and "Log Work" labels
- [ ] Verify My Strategy saves and loads correctly
- [ ] Verify resume upload works
- [ ] Verify Employment Records tab loads with filters and CRUD