### PR TITLE
fix(assessment): surface real error message on failed submission

### DIFF
--- a/src/pages/Assessment/components/AssessmentLayout/AssessmentLayout.jsx
+++ b/src/pages/Assessment/components/AssessmentLayout/AssessmentLayout.jsx
@@ -221,10 +221,24 @@ function AssessmentLayout({ readonly = false }) {
     }
   };
 
+  const readSubmitErrorMessage = async (response) => {
+    if (response.status === 413) {
+      return 'Your submission is too large. Try removing or trimming uploaded files and resubmit.';
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      try {
+        const errorData = await response.json();
+        if (errorData?.error) return errorData.error;
+      } catch { /* fall through */ }
+    }
+    return `Server error (${response.status}). Please try again or contact support.`;
+  };
+
   const saveSubmissionData = async (submissionData, status = 'submitted') => {
     try {
       console.log('AssessmentLayout: Saving submission data to backend:', { submissionData, status });
-      
+
       const response = await fetch(`${import.meta.env.VITE_API_URL}/api/assessments/${assessmentId}/submissions`, {
         method: 'POST',
         headers: {
@@ -236,17 +250,17 @@ function AssessmentLayout({ readonly = false }) {
           status: status
         })
       });
-      
+
       if (response.ok) {
         console.log('AssessmentLayout: Submission data saved successfully');
-        return true;
-      } else {
-        console.error('AssessmentLayout: Failed to save submission data:', response.status);
-        return false;
+        return { ok: true };
       }
+      const message = await readSubmitErrorMessage(response);
+      console.error('AssessmentLayout: Failed to save submission data:', response.status, message);
+      return { ok: false, message };
     } catch (error) {
       console.error('Error saving submission:', error);
-      return false;
+      return { ok: false, message: error.message || 'Network error. Please check your connection and try again.' };
     }
   };
 
@@ -254,14 +268,14 @@ function AssessmentLayout({ readonly = false }) {
     try {
       setSubmissionState(prev => ({ ...prev, isLoading: true }));
       
-      const success = await saveSubmissionData(submissionData, 'submitted');
-      
-      if (!success) {
+      const result = await saveSubmissionData(submissionData, 'submitted');
+
+      if (!result.ok) {
         setSubmissionState(prev => ({ ...prev, isLoading: false }));
-        
+
         Swal.fire({
           title: 'Submission Failed',
-          text: 'There was an error submitting your assessment. Please try again.',
+          text: result.message || 'There was an error submitting your assessment. Please try again.',
           icon: 'error',
           confirmButtonColor: '#dc3545',
           background: '#1A1F2C',
@@ -348,8 +362,8 @@ function AssessmentLayout({ readonly = false }) {
         // Navigate back to assessments list
         navigate('/assessment');
       } else {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Resubmission failed');
+        const message = await readSubmitErrorMessage(response);
+        throw new Error(message);
       }
     } catch (error) {
       console.error('Error submitting resubmission:', error);


### PR DESCRIPTION
Both saveSubmissionData() and handleResubmissionSubmit() previously called response.json() (or returned a plain false) regardless of what the server sent back. When the request was rejected by Express middleware (e.g. 413 Payload Too Large from oversized file uploads), the response body was HTML, the JSON parse crashed, and the user saw "JSON.parse: unexpected character at line 1 column 1" with no idea what to fix.

Adds a small readSubmitErrorMessage() helper that:
- returns a friendly "submission too large" message on 413,
- only parses the body as JSON when content-type matches,
- otherwise falls back to "Server error (NNN). Please try again or contact support." instead of crashing the parser.

Both submission paths now route their error display through Swal with the real message.